### PR TITLE
Update wiki link in sidebar

### DIFF
--- a/src/_includes/sidebar.html
+++ b/src/_includes/sidebar.html
@@ -19,7 +19,7 @@
         <li><a href="/help.html">Help</a></li>
         <li><a href="/quickstart.html">Quickstart</a></li>
         <li><a href="/developers.html">Developers</a></li>
-        <li><a href="/wiki/">Wiki</a></li>
+        <li><a href="https://projects.clusterlabs.org/w/">Wiki</a></li>
       </ul>  
     </nav>
 


### PR DESCRIPTION
Hello.

The link to the wiki in the sidebar is broken.