### PR TITLE
Version typo

### DIFF
--- a/src/static/projects/pacemaker/doc/desc-3.0.txt
+++ b/src/static/projects/pacemaker/doc/desc-3.0.txt
@@ -1,1 +1,1 @@
-Clusters From Scratch demonstrates Pacemaker 2.1 with Corosync 3
+Clusters From Scratch demonstrates Pacemaker 3.0 with Corosync 3


### PR DESCRIPTION
When you go to https://clusterlabs.org/projects/pacemaker/doc/index.php#versioned-documentation you will see under `Pacemaker 3.0` there's a version typo in the description.